### PR TITLE
chore: remove unused deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,6 @@
     "@mui/material": "^5.0.4",
     "autoprefixer": "^10.4.0",
     "history": "^5.3.0",
-    "lodash": "^4.17.15",
     "mobx": "^6.1.0",
     "mobx-react-lite": "^3.4.0",
     "moment": "^2.29.4",
@@ -87,7 +86,6 @@
     "react-dom": "^18.0.0",
     "react-grid-system": "^8.2.1",
     "react-router-dom": "^6.0.0",
-    "react-typed": "^2.0.0",
-    "styled-components": "^6.1.9"
+    "react-typed": "^2.0.0"
   }
 }


### PR DESCRIPTION
## Summary
- remove styled-components and lodash from runtime dependencies

## Testing
- `npm uninstall styled-components lodash --force --legacy-peer-deps --no-save` *(fails: No matching version found for @types/react-router-dom@^6.0.0)*
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689f431de0608320a7813123c715d66a