### PR TITLE
refactor: replace moment with dayjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "lodash": "^4.17.15",
     "mobx": "^6.1.0",
     "mobx-react-lite": "^3.4.0",
-    "moment": "^2.29.4",
+    "dayjs": "^1.11.10",
     "react": "^18.0.0",
     "framer-motion": "^10.16.4",
     "react-dom": "^18.0.0",

--- a/src/stores/app/index.ts
+++ b/src/stores/app/index.ts
@@ -1,5 +1,5 @@
 import { observable } from 'mobx'
-import moment from 'moment'
+import dayjs from 'dayjs'
 import { ScreenClass } from 'react-grid-system'
 
 import history from '../../utils/history'
@@ -29,7 +29,7 @@ const createStore = (): typeof appStore => {
       if (!resumeArray) return []
 
       return [...resumeArray].sort((a, b) => {
-        return moment(b.startAt).unix() - moment(a.startAt).unix()
+        return dayjs(b.startAt).unix() - dayjs(a.startAt).unix()
       })
     },
     get studyArrayInLatestOrder(): Array<ResumeObject> {
@@ -37,7 +37,7 @@ const createStore = (): typeof appStore => {
       if (!studyArray) return []
 
       return [...studyArray].sort((a, b) => {
-        return moment(b.startAt).unix() - moment(a.startAt).unix()
+        return dayjs(b.startAt).unix() - dayjs(a.startAt).unix()
       })
     },
 


### PR DESCRIPTION
## Summary
- replace deprecated moment usage with dayjs in application store
- remove moment dependency and add dayjs

## Testing
- `npm install --legacy-peer-deps` *(fails: No matching version found for @types/react-router-dom@^6.0.0)*
- `npm test` *(fails: Error: no test specified)*
- `npm run build` *(fails: cross-env: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689f432628b883208bc20d2165799906